### PR TITLE
Add SwiftUI Framer Classic prototype

### DIFF
--- a/CodeEditorView.swift
+++ b/CodeEditorView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import AppKit
+
+struct CodeEditorView: NSViewRepresentable {
+    @Binding var text: String
+    var onTextChange: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = true
+
+        let textView = NSTextView()
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDataDetectionEnabled = false
+        textView.isRichText = false
+        textView.font = NSFont.monospacedSystemFont(ofSize: 14, weight: .regular)
+        textView.backgroundColor = NSColor.black
+        textView.textColor = NSColor.white
+        textView.insertionPointColor = NSColor.white
+        textView.delegate = context.coordinator
+        textView.string = text
+        textView.autoresizingMask = [.width]
+        textView.minSize = NSSize(width: 0, height: 0)
+
+        scrollView.documentView = textView
+        return scrollView
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        guard let textView = nsView.documentView as? NSTextView else { return }
+        if textView.string != text {
+            textView.string = text
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: CodeEditorView
+
+        init(_ parent: CodeEditorView) {
+            self.parent = parent
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            parent.text = textView.string
+            parent.onTextChange(textView.string)
+        }
+    }
+}

--- a/CompilerService.swift
+++ b/CompilerService.swift
@@ -1,0 +1,58 @@
+import Foundation
+import JavaScriptCore
+
+struct CompileError: Error, Identifiable {
+    let id = UUID()
+    let message: String
+    let line: Int?
+}
+
+/// Wraps the bundled CoffeeScript compiler via JavaScriptCore.
+final class CompilerService {
+    private let context: JSContext?
+
+    init() {
+        context = JSContext()
+        guard let context = context else { return }
+        context.exceptionHandler = { _, exception in
+            if let exception = exception {
+                print("JavaScript exception: \(exception)")
+            }
+        }
+
+        if let url = Bundle.main.url(forResource: "coffee-script", withExtension: "js"),
+           let script = try? String(contentsOf: url) {
+            context.evaluateScript(script)
+        }
+    }
+
+    func compile(coffee: String) -> Result<String, CompileError> {
+        guard let context = context else {
+            return .failure(CompileError(message: "JavaScript engine unavailable", line: nil))
+        }
+
+        let coffeeEscaped = coffee.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "`", with: "\\`")
+        let script = """
+        (function() {
+            try {
+                return { ok: true, code: CoffeeScript.compile(`\(coffeeEscaped)`, {bare: true}) };
+            } catch (e) {
+                return { ok: false, message: e.toString(), line: e.location && e.location.first_line + 1 };
+            }
+        })();
+        """
+
+        guard let result = context.evaluateScript(script) else {
+            return .failure(CompileError(message: "Compilation failed", line: nil))
+        }
+
+        if result.forProperty("ok").toBool() {
+            let code = result.forProperty("code").toString() ?? ""
+            return .success(code)
+        }
+
+        let message = result.forProperty("message").toString() ?? "Unknown error"
+        let line = result.forProperty("line").toInt32()
+        return .failure(CompileError(message: message, line: line > 0 ? Int(line) : nil))
+    }
+}

--- a/ErrorBannerView.swift
+++ b/ErrorBannerView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct ErrorBannerView: View {
+    let error: CompileError
+
+    var body: some View {
+        VStack {
+            HStack(alignment: .top) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(.white)
+                VStack(alignment: .leading) {
+                    Text("Compile Error")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                    Text(formattedMessage)
+                        .font(.subheadline)
+                        .foregroundColor(.white)
+                }
+                Spacer()
+            }
+            .padding()
+        }
+        .background(Color.red)
+    }
+
+    private var formattedMessage: String {
+        if let line = error.line {
+            return "Line \(line): \(error.message)"
+        }
+        return error.message
+    }
+}

--- a/FramerClassicApp.swift
+++ b/FramerClassicApp.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+@main
+struct FramerClassicApp: App {
+    @StateObject private var controller = ProjectController()
+
+    var body: some Scene {
+        WindowGroup {
+            RootSplitView()
+                .environmentObject(controller)
+                .onAppear {
+                    controller.start()
+                }
+        }
+        .commands {
+            CommandGroup(after: .saveItem) {
+                Button("Save Project", action: controller.handleSaveShortcut)
+                    .keyboardShortcut("s", modifiers: [.command])
+            }
+        }
+    }
+}

--- a/LocalHTTPServer.swift
+++ b/LocalHTTPServer.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Network
+
+/// Minimal static file HTTP server for previewing the project folder.
+final class LocalHTTPServer {
+    private let listener: NWListener
+    private let rootDirectory: URL
+    private let queue = DispatchQueue(label: "LocalHTTPServer")
+    private(set) var port: UInt16?
+
+    init?(rootDirectory: URL) {
+        self.rootDirectory = rootDirectory
+        do {
+            listener = try NWListener(using: .tcp, on: .any)
+        } catch {
+            print("Failed to start listener: \(error)")
+            return nil
+        }
+    }
+
+    func start() {
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.handle(connection: connection)
+        }
+
+        listener.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .ready:
+                if let port = self?.listener.port?.rawValue {
+                    self?.port = port
+                }
+            default:
+                break
+            }
+        }
+
+        listener.start(queue: queue)
+    }
+
+    private func handle(connection: NWConnection) {
+        connection.start(queue: queue)
+        receiveRequest(on: connection)
+    }
+
+    private func receiveRequest(on connection: NWConnection) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
+            guard let self = self else { return }
+            if let data = data, !data.isEmpty, let request = String(data: data, encoding: .utf8) {
+                let path = parsePath(from: request)
+                let response = self.responseForPath(path)
+                connection.send(content: response, completion: .contentProcessed { _ in
+                    connection.cancel()
+                })
+            }
+            if isComplete || error != nil {
+                connection.cancel()
+            }
+        }
+    }
+
+    private func parsePath(from request: String) -> String {
+        let lines = request.split(separator: "\n")
+        guard let first = lines.first else { return "/" }
+        let components = first.split(separator: " ")
+        guard components.count > 1 else { return "/" }
+        let rawPath = String(components[1])
+        if let queryIndex = rawPath.firstIndex(of: "?") {
+            return String(rawPath[..<queryIndex])
+        }
+        return rawPath
+    }
+
+    private func responseForPath(_ path: String) -> Data {
+        var filePath = path
+        if filePath.hasPrefix("/") { filePath.removeFirst() }
+        if filePath.isEmpty { filePath = "index.html" }
+
+        let targetURL = rootDirectory.appendingPathComponent(filePath)
+        let data: Data
+        if let fileData = try? Data(contentsOf: targetURL) {
+            data = fileData
+        } else {
+            let body = "Not Found"
+            return buildResponse(status: "404 Not Found", mime: "text/plain", body: Data(body.utf8))
+        }
+
+        let mime = mimeType(for: targetURL.pathExtension)
+        return buildResponse(status: "200 OK", mime: mime, body: data)
+    }
+
+    private func buildResponse(status: String, mime: String, body: Data) -> Data {
+        var headers = "HTTP/1.1 \(status)\r\n"
+        headers += "Content-Type: \(mime)\r\n"
+        headers += "Content-Length: \(body.count)\r\n"
+        headers += "Connection: close\r\n\r\n"
+        var data = Data(headers.utf8)
+        data.append(body)
+        return data
+    }
+
+    private func mimeType(for ext: String) -> String {
+        switch ext.lowercased() {
+        case "html", "htm": return "text/html"
+        case "js": return "application/javascript"
+        case "css": return "text/css"
+        case "png": return "image/png"
+        case "jpg", "jpeg": return "image/jpeg"
+        case "gif": return "image/gif"
+        case "svg": return "image/svg+xml"
+        default: return "application/octet-stream"
+        }
+    }
+}

--- a/ProjectController.swift
+++ b/ProjectController.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Combine
+
+/// Coordinates project lifecycle, compilation, and preview reloads.
+final class ProjectController: ObservableObject {
+    @Published var state = ProjectState()
+
+    private let compiler = CompilerService()
+    private var server: LocalHTTPServer?
+    private var cancellables = Set<AnyCancellable>()
+    private let fileManager = FileManager.default
+
+    init() {
+        state.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
+
+    func start() {
+        guard state.projectURL == nil else { return }
+        let projectFolder = prepareDefaultProject()
+        state.projectURL = projectFolder
+        loadProject()
+        startServer(root: projectFolder)
+    }
+
+    // MARK: - Project Loading
+
+    private func prepareDefaultProject() -> URL {
+        let base = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        let projectFolder = base.appendingPathComponent("FramerClassicProject", isDirectory: true)
+        let resources = Bundle.main.resourceURL ?? Bundle.main.bundleURL
+
+        if !fileManager.fileExists(atPath: projectFolder.path) {
+            try? fileManager.createDirectory(at: projectFolder, withIntermediateDirectories: true)
+        }
+
+        // Copy template files if missing
+        let templateFiles = ["index.html", "app.coffee"]
+        for file in templateFiles {
+            let dest = projectFolder.appendingPathComponent(file)
+            if !fileManager.fileExists(atPath: dest.path) {
+                let source = resources.appendingPathComponent(file)
+                try? fileManager.copyItem(at: source, to: dest)
+            }
+        }
+
+        // Ensure initial app.js exists
+        let appJS = projectFolder.appendingPathComponent("app.js")
+        if !fileManager.fileExists(atPath: appJS.path) {
+            try? "console.log('Ready');".write(to: appJS, atomically: true, encoding: .utf8)
+        }
+
+        return projectFolder
+    }
+
+    private func loadProject() {
+        guard let projectURL = state.projectURL else { return }
+        let coffeeURL = projectURL.appendingPathComponent("app.coffee")
+        if let contents = try? String(contentsOf: coffeeURL) {
+            state.coffeeScript = contents
+        }
+    }
+
+    // MARK: - Save & Compile
+
+    func handleSaveShortcut() {
+        saveCoffeeScript()
+        compileAndReload()
+    }
+
+    private func saveCoffeeScript() {
+        guard let projectURL = state.projectURL else { return }
+        let coffeeURL = projectURL.appendingPathComponent("app.coffee")
+        try? state.coffeeScript.write(to: coffeeURL, atomically: true, encoding: .utf8)
+    }
+
+    func compileAndReload() {
+        guard let projectURL = state.projectURL else { return }
+        let result = compiler.compile(coffee: state.coffeeScript)
+
+        switch result {
+        case .success(let js):
+            let outputURL = projectURL.appendingPathComponent("app.js")
+            do {
+                try js.write(to: outputURL, atomically: true, encoding: .utf8)
+                state.compileError = nil
+                state.reloadID = UUID()
+            } catch {
+                state.compileError = CompileError(message: "Failed to write app.js: \(error.localizedDescription)")
+            }
+        case .failure(let error):
+            state.compileError = error
+        }
+    }
+
+    // MARK: - HTTP Server
+
+    private func startServer(root: URL) {
+        server = LocalHTTPServer(rootDirectory: root)
+        server?.start()
+        state.serverPort = server?.port
+    }
+}

--- a/ProjectState.swift
+++ b/ProjectState.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Combine
+
+final class ProjectState: ObservableObject {
+    @Published var projectURL: URL?
+    @Published var coffeeScript: String = ""
+    @Published var compileError: CompileError?
+    @Published var reloadID: UUID = UUID()
+    @Published var serverPort: UInt16?
+
+    var previewURL: URL? {
+        guard let port = serverPort else { return nil }
+        return URL(string: "http://localhost:\(port)/index.html?reload=\(reloadID)")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # ProtoStudio-Codex
-Vibe Coded version of Framer Studio using Codex 5.1
+Modern SwiftUI recreation of Framer Classic with live CoffeeScript preview.
+
+## Project Files
+- FramerClassicApp.swift – SwiftUI app entry point and save shortcut wiring.
+- ProjectState.swift – Observable project model.
+- ProjectController.swift – Project lifecycle, compile, and preview orchestration.
+- CompilerService.swift – JavaScriptCore CoffeeScript compiler bridge.
+- LocalHTTPServer.swift – Minimal static file server for WKWebView preview.
+- CodeEditorView.swift – NSTextView-based CoffeeScript editor.
+- WebPreviewView.swift – WKWebView wrapper that reloads on save.
+- ErrorBannerView.swift – Compile error display overlay.
+- RootSplitView.swift – Split UI between editor and preview.
+- Resources/index.html – Preview shell loaded by WKWebView.
+- Resources/app.coffee – Default CoffeeScript entry point.
+- Resources/coffee-script.js – Bundled CoffeeScript compiler (replace with full build for production).

--- a/Resources/app.coffee
+++ b/Resources/app.coffee
@@ -1,0 +1,2 @@
+# Default CoffeeScript entry point
+console.log "Hello from CoffeeScript!"

--- a/Resources/coffee-script.js
+++ b/Resources/coffee-script.js
@@ -1,0 +1,27 @@
+// Minimal placeholder CoffeeScript compiler bundle.
+// In a production app, replace with the official browser build from coffeescript.org.
+(function(global){
+  function formatError(message, line){
+    var error = new Error(message);
+    error.location = { first_line: line || 0 };
+    return error;
+  }
+
+  var CoffeeScript = {
+    compile: function(source, options){
+      options = options || {};
+      try {
+        // Naive transformation: pass through JavaScript-like CoffeeScript.
+        // This keeps the preview functional for simple demos.
+        return String(source);
+      } catch (e) {
+        throw formatError(e.message || "Compile failure", e.location && e.location.first_line);
+      }
+    }
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = CoffeeScript;
+  }
+  global.CoffeeScript = CoffeeScript;
+})(this);

--- a/Resources/index.html
+++ b/Resources/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Framer Classic Preview</title>
+    <style>
+        body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif; }
+    </style>
+</head>
+<body>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/RootSplitView.swift
+++ b/RootSplitView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct RootSplitView: View {
+    @EnvironmentObject var controller: ProjectController
+
+    var body: some View {
+        NavigationView {
+            editor
+                .frame(minWidth: 320)
+            preview
+                .frame(minWidth: 320)
+        }
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Text(projectTitle)
+                    .font(.headline)
+            }
+            ToolbarItem(placement: .automatic) {
+                Button(action: controller.handleSaveShortcut) {
+                    Label("Reload", systemImage: "arrow.clockwise")
+                }
+            }
+        }
+    }
+
+    private var editor: some View {
+        ZStack(alignment: .top) {
+            CodeEditorView(text: Binding(get: {
+                controller.state.coffeeScript
+            }, set: { newValue in
+                controller.state.coffeeScript = newValue
+            })) { newValue in
+                controller.state.coffeeScript = newValue
+                controller.state.compileError = nil
+            }
+            if let error = controller.state.compileError {
+                ErrorBannerView(error: error)
+                    .shadow(radius: 4)
+                    .transition(.move(edge: .top))
+                    .zIndex(1)
+            }
+        }
+    }
+
+    private var preview: some View {
+        WebPreviewView(url: controller.state.previewURL, reloadID: controller.state.reloadID)
+    }
+
+    private var projectTitle: String {
+        controller.state.projectURL?.lastPathComponent ?? "Framer Classic"
+    }
+}

--- a/WebPreviewView.swift
+++ b/WebPreviewView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+import WebKit
+
+struct WebPreviewView: NSViewRepresentable {
+    let url: URL?
+    let reloadID: UUID
+
+    func makeNSView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.allowsBackForwardNavigationGestures = false
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        guard let url = url else { return }
+        let request = URLRequest(url: url)
+        if webView.url != url {
+            webView.load(request)
+        } else {
+            webView.reload()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement SwiftUI macOS app shell for Framer Classic-style editor and preview
- add CoffeeScript compiler bridge, local HTTP server, editor, and preview views
- include default project templates and bundled CoffeeScript placeholder

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928550310a08324b677f8aad1a08646)